### PR TITLE
fix for newest versions of skimage

### DIFF
--- a/src/ScreenCompareLibrary/keywords/_compare.py
+++ b/src/ScreenCompareLibrary/keywords/_compare.py
@@ -4,7 +4,7 @@ import os
 import cv2
 import numpy
 from robot.api import logger
-from skimage.measure import compare_ssim
+from skimage.util import compare_images
 
 
 class _Compare:


### PR DESCRIPTION
from skimage version 0.16 is new compare_images
compare_ssim is deprecated from  0.18